### PR TITLE
Fixes the price history chart showing only 1 week of data for new products.

### DIFF
--- a/backend/db/connection.py
+++ b/backend/db/connection.py
@@ -1,5 +1,7 @@
 import os
 from datetime import datetime
+from typing import Optional
+
 from dotenv import load_dotenv
 import mysql.connector
 from mysql.connector import pooling
@@ -71,9 +73,18 @@ def insert_product(asin, title, brand, category):
 
 
 
-def insert_price(product_id, price, availability=True, deal_flag=False):
+def insert_price(
+    product_id,
+    price,
+    availability=True,
+    deal_flag=False,
+    *,
+    recorded_at: Optional[datetime] = None,
+):
+    """Insert a price row. Pass ``recorded_at`` for historical samples (e.g. Keepa); else UTC now."""
     conn = None
     cursor = None
+    ts = recorded_at if recorded_at is not None else datetime.utcnow()
     try:
         conn = get_connection()
         cursor = conn.cursor()
@@ -81,7 +92,7 @@ def insert_price(product_id, price, availability=True, deal_flag=False):
             INSERT INTO prices (product_id, price, timestamp, availability, deal_flag)
             VALUES (%s, %s, %s, %s, %s)
         """
-        cursor.execute(query, (product_id, price, datetime.now(), availability, deal_flag))
+        cursor.execute(query, (product_id, price, ts, availability, deal_flag))
         conn.commit()
     except Exception as e:
         if conn:

--- a/backend/jobs/keepa_fetch.py
+++ b/backend/jobs/keepa_fetch.py
@@ -136,5 +136,11 @@ def _write_to_db(asin: str, name: str, records: list[dict]) -> None:
 
     product_id = product["product_id"]
     for record in records:
-        ts = datetime.utcfromtimestamp(record["timestamp"])
-        insert_price(product_id, record["price"], availability=True, deal_flag=False)
+        ts = datetime.utcfromtimestamp(int(record["timestamp"]))
+        insert_price(
+            product_id,
+            record["price"],
+            availability=True,
+            deal_flag=False,
+            recorded_at=ts,
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -142,43 +142,119 @@ def _generate_why(
     )
 
 
+def _day_label_utc(d: datetime) -> str:
+    """Chart x-axis: month abbreviation + day (UTC calendar day)."""
+    return f"{d.strftime('%b')} {d.day}"
+
+
 def _bucket_price_history(
     prices: list, prediction: Optional[dict], asin: str
 ) -> PriceHistoryResponse:
+    """~30 daily actuals (forward-filled EOD per UTC day) plus forecast points."""
     now = datetime.utcnow()
-    prices_asc = list(reversed(prices))  # prices come in DESC from DB
-
-    points: List[PricePoint] = []
-    for weeks_back in range(4, 0, -1):
-        start = now - timedelta(weeks=weeks_back)
-        end = now - timedelta(weeks=weeks_back - 1)
-        bucket = [
-            float(p["price"]) for p in prices_asc
-            if start <= p["timestamp"] < end
-        ]
-        if bucket:
-            avg = round(sum(bucket) / len(bucket), 2)
-            points.append(PricePoint(label=f"-{weeks_back}w", actual=avg))
+    prices_asc = sorted(prices, key=lambda p: p["timestamp"])
 
     current_price = float(prices[0]["price"]) if prices else 0.0
 
-    if prediction:
-        points.append(PricePoint(label="Today", actual=current_price, predicted=current_price))
-        if prediction.get("pred_7d") is not None:
-            points.append(PricePoint(label="+1w", predicted=float(prediction["pred_7d"])))
-        if prediction.get("pred_14d") is not None:
-            points.append(PricePoint(label="+2w", predicted=float(prediction["pred_14d"])))
-        if prediction.get("pred_30d") is not None:
-            points.append(PricePoint(label="+1m", predicted=float(prediction["pred_30d"])))
+    points: List[PricePoint] = []
+    if prices_asc:
+        now_date = now.date()
+        last_close: Optional[float] = None
+        p_i = 0
+        n = len(prices_asc)
+
+        for days_back in range(29, -1, -1):
+            day = now_date - timedelta(days=days_back)
+            next_day = day + timedelta(days=1)
+            day_end_excl = datetime.combine(next_day, datetime.min.time())
+
+            while p_i < n and prices_asc[p_i]["timestamp"] < day_end_excl:
+                last_close = float(prices_asc[p_i]["price"])
+                p_i += 1
+
+            if last_close is None:
+                continue
+
+            label = _day_label_utc(datetime.combine(day, datetime.min.time()))
+            is_today = days_back == 0
+            if is_today and prediction:
+                points.append(
+                    PricePoint(
+                        label=label,
+                        actual=round(last_close, 2),
+                        predicted=round(last_close, 2),
+                    )
+                )
+            else:
+                points.append(PricePoint(label=label, actual=round(last_close, 2)))
+
+        if prediction:
+            if prediction.get("pred_7d") is not None:
+                d = now_date + timedelta(days=7)
+                points.append(
+                    PricePoint(
+                        label=_day_label_utc(datetime.combine(d, datetime.min.time())),
+                        predicted=round(float(prediction["pred_7d"]), 2),
+                    )
+                )
+            if prediction.get("pred_14d") is not None:
+                d = now_date + timedelta(days=14)
+                points.append(
+                    PricePoint(
+                        label=_day_label_utc(datetime.combine(d, datetime.min.time())),
+                        predicted=round(float(prediction["pred_14d"]), 2),
+                    )
+                )
+            if prediction.get("pred_30d") is not None:
+                d = now_date + timedelta(days=30)
+                points.append(
+                    PricePoint(
+                        label=_day_label_utc(datetime.combine(d, datetime.min.time())),
+                        predicted=round(float(prediction["pred_30d"]), 2),
+                    )
+                )
     else:
-        points.append(PricePoint(label="Today", actual=current_price))
+        if prediction:
+            points.append(
+                PricePoint(
+                    label=_day_label_utc(now),
+                    actual=current_price,
+                    predicted=current_price,
+                )
+            )
+            if prediction.get("pred_7d") is not None:
+                d = now.date() + timedelta(days=7)
+                points.append(
+                    PricePoint(
+                        label=_day_label_utc(datetime.combine(d, datetime.min.time())),
+                        predicted=round(float(prediction["pred_7d"]), 2),
+                    )
+                )
+            if prediction.get("pred_14d") is not None:
+                d = now.date() + timedelta(days=14)
+                points.append(
+                    PricePoint(
+                        label=_day_label_utc(datetime.combine(d, datetime.min.time())),
+                        predicted=round(float(prediction["pred_14d"]), 2),
+                    )
+                )
+            if prediction.get("pred_30d") is not None:
+                d = now.date() + timedelta(days=30)
+                points.append(
+                    PricePoint(
+                        label=_day_label_utc(datetime.combine(d, datetime.min.time())),
+                        predicted=round(float(prediction["pred_30d"]), 2),
+                    )
+                )
+        else:
+            points.append(PricePoint(label=_day_label_utc(now), actual=current_price))
 
     future_preds = [p.predicted for p in points if p.predicted is not None]
     predicted_best = min(future_preds) if future_preds else current_price
 
     return PriceHistoryResponse(
         asin=asin,
-        chart_title="Price history & 30-day forecast",
+        chart_title="Price history (30 days, UTC) & forecast",
         current_price=current_price,
         predicted_best_price=round(predicted_best, 2),
         points=points,
@@ -204,7 +280,7 @@ def _fetch_and_seed(asin: str) -> None:
     if not product:
         return
 
-    prices = db_get_price_history(product["product_id"], limit=100)
+    prices = db_get_price_history(product["product_id"], limit=1000)
     if not prices:
         return
 
@@ -314,7 +390,7 @@ def get_price_history(asin: str) -> PriceHistoryResponse:
     if not product:
         raise HTTPException(status_code=404, detail="not_tracked")
 
-    prices = db_get_price_history(product["product_id"], limit=100)
+    prices = db_get_price_history(product["product_id"], limit=1000)
     prediction = get_latest_prediction(product["product_id"])
 
     return _bucket_price_history(prices, prediction, asin)

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,9 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
+from routes.dashboard import router as dashboard_router
+from schemas.common import RecommendationDirection
+
 logger = logging.getLogger(__name__)
 
 # Lazy DB import — server stays up even if DB is unavailable at startup
@@ -26,9 +29,11 @@ except Exception as _exc:
 
 app = FastAPI(
     title="BuyWise API",
-    description="Backend for the BuyWise Chrome extension.",
+    description="Backend for the BuyWise Chrome extension and web dashboard.",
     version="0.1.0",
 )
+
+app.include_router(dashboard_router)
 
 app.add_middleware(
     CORSMiddleware,
@@ -58,11 +63,6 @@ async def private_network_access(request: Request, call_next):
 class HealthResponse(BaseModel):
     status: str = Field(..., example="ok")
     started_at: datetime = Field(..., example="2026-03-16T00:00:00Z")
-
-
-class RecommendationDirection(str, Enum):
-    BUY = "BUY"
-    WAIT = "WAIT"
 
 
 class PredictResponse(BaseModel):

--- a/backend/routes/dashboard.py
+++ b/backend/routes/dashboard.py
@@ -1,1 +1,417 @@
-# routes/dashboard.py - API routes for the dashboard
+"""Dashboard API routes — aggregate history and stats for the web dashboard (mock data).
+
+Extension endpoints live on the root app in `main.py`; dashboard routes are prefixed
+with `/dashboard` and do not require the database.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from fastapi import APIRouter, Query
+from pydantic import BaseModel, Field
+
+from schemas.common import RecommendationDirection
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+class OutcomeStatus(str, Enum):
+    """Whether the eventual price movement matched our recommendation."""
+
+    pending = "pending"
+    correct = "correct"
+    incorrect = "incorrect"
+    partial = "partial"
+
+
+# ── Summary ─────────────────────────────────────────────────────────────────
+
+
+class DashboardSummaryResponse(BaseModel):
+    """Headline KPIs for the dashboard hero section."""
+
+    user_id: str = Field(..., example="user_demo_001")
+    total_predictions: int = Field(..., ge=0, example=47)
+    recommendations_followed: int = Field(..., ge=0, example=31)
+    estimated_savings_usd: float = Field(..., example=284.5)
+    accuracy_when_followed_pct: float = Field(..., ge=0, le=100, example=82.3)
+    avg_confidence_when_correct_pct: float = Field(..., ge=0, le=100, example=79.1)
+    watchlist_count: int = Field(..., ge=0, example=8)
+    last_active_at: datetime = Field(..., example="2026-03-28T14:22:00Z")
+    period_label: str = Field(..., example="Last 90 days")
+
+
+# ── Prediction history ────────────────────────────────────────────────────────
+
+
+class PredictionHistoryItem(BaseModel):
+    prediction_id: str = Field(..., example="pred_20260315_01")
+    asin: str = Field(..., example="B08N5WRWNW")
+    product_title: str = Field(..., example="Wireless Noise-Cancelling Headphones")
+    recommendation: RecommendationDirection = Field(..., example="WAIT")
+    confidence_pct: float = Field(..., ge=0, le=100, example=87.0)
+    price_at_prediction_usd: float = Field(..., example=199.99)
+    predicted_best_price_usd: float = Field(..., example=169.99)
+    horizon_days: int = Field(..., ge=1, example=14)
+    predicted_at: datetime = Field(..., example="2026-03-01T18:30:00Z")
+    outcome: OutcomeStatus = Field(..., example="correct")
+    actual_lowest_price_usd: Optional[float] = Field(None, example=164.5)
+    outcome_resolved_at: Optional[datetime] = Field(None, example="2026-03-14T09:00:00Z")
+    savings_realized_usd: Optional[float] = Field(None, example=35.49)
+
+
+class PredictionHistoryResponse(BaseModel):
+    items: List[PredictionHistoryItem]
+    total_count: int = Field(..., ge=0, example=47)
+    limit: int = Field(..., ge=1, example=20)
+    offset: int = Field(..., ge=0, example=0)
+
+
+# ── Watchlist ─────────────────────────────────────────────────────────────────
+
+
+class WatchlistItem(BaseModel):
+    asin: str = Field(..., example="B0BSHF7WHW")
+    title: str = Field(..., example="USB-C Laptop Docking Station")
+    brand: Optional[str] = Field(None, example="Anker")
+    category: Optional[str] = Field(None, example="Electronics")
+    current_price_usd: float = Field(..., example=89.99)
+    currency: str = Field(..., example="USD")
+    target_price_usd: Optional[float] = Field(None, example=74.99)
+    added_at: datetime = Field(..., example="2026-02-10T12:00:00Z")
+    last_price_change_pct: Optional[float] = Field(None, description="vs. price when added", example=-3.2)
+    url: str = Field(..., example="https://www.amazon.com/dp/B0BSHF7WHW")
+
+
+class WatchlistResponse(BaseModel):
+    items: List[WatchlistItem]
+    total_count: int = Field(..., ge=0, example=8)
+
+
+# ── Market context (categories / segments user cares about) ─────────────────
+
+
+class CategoryMarketTrend(BaseModel):
+    category: str = Field(..., example="Electronics › Headphones")
+    median_price_change_7d_pct: float = Field(..., example=-2.1)
+    median_price_change_30d_pct: float = Field(..., example=-5.4)
+    deal_intensity_index: float = Field(
+        ...,
+        ge=0,
+        le=100,
+        description="Heuristic 0–100: higher = more promotional activity in segment",
+        example=62.0,
+    )
+    sample_product_count: int = Field(..., ge=0, example=128)
+
+
+class SegmentMover(BaseModel):
+    asin: str = Field(..., example="B09V3KXJPB")
+    title: str = Field(..., example="Compact Mechanical Keyboard")
+    category: str = Field(..., example="Electronics › Keyboards")
+    price_change_7d_pct: float = Field(..., example=-11.4)
+    current_price_usd: float = Field(..., example=79.99)
+
+
+class MarketContextResponse(BaseModel):
+    """Benchmark-style view around categories the user commonly interacts with."""
+
+    user_top_categories: List[str] = Field(
+        ...,
+        example=["Electronics", "Computer Accessories", "Travel Gear"],
+    )
+    category_trends: List[CategoryMarketTrend]
+    notable_movers: List[SegmentMover]
+    narrative: str = Field(
+        ...,
+        example=(
+            "Deals in your usual electronics categories are slightly stronger than "
+            "last month; headphones and docks show the steepest week-over-week drops."
+        ),
+    )
+    as_of: datetime = Field(..., example="2026-04-01T08:00:00Z")
+
+
+# ── Performance over time (for charts) ──────────────────────────────────────
+
+
+class PerformancePeriodPoint(BaseModel):
+    period_start: datetime = Field(..., example="2026-01-06T00:00:00Z")
+    period_end: datetime = Field(..., example="2026-01-12T23:59:59Z")
+    predictions_made: int = Field(..., ge=0, example=6)
+    predictions_followed: int = Field(..., ge=0, example=4)
+    accuracy_pct: Optional[float] = Field(None, ge=0, le=100, example=75.0)
+    savings_usd: float = Field(..., example=42.0)
+
+
+class PerformanceTimeseriesResponse(BaseModel):
+    granularity: str = Field(..., example="week")
+    points: List[PerformancePeriodPoint]
+
+
+class OutcomeBreakdownSlice(BaseModel):
+    outcome: OutcomeStatus
+    count: int = Field(..., ge=0, example=12)
+    share_pct: float = Field(..., ge=0, le=100, example=25.5)
+
+
+class OutcomeBreakdownResponse(BaseModel):
+    slices: List[OutcomeBreakdownSlice]
+    total_resolved: int = Field(..., ge=0, example=39)
+
+
+# ── Mock payloads ─────────────────────────────────────────────────────────────
+
+_MOCK_HISTORY: List[PredictionHistoryItem] = [
+    PredictionHistoryItem(
+        prediction_id="pred_20260328_01",
+        asin="B08N5WRWNW",
+        product_title="Wireless Noise-Cancelling Headphones",
+        recommendation=RecommendationDirection.WAIT,
+        confidence_pct=87.0,
+        price_at_prediction_usd=199.99,
+        predicted_best_price_usd=169.99,
+        horizon_days=14,
+        predicted_at=datetime(2026, 3, 15, 18, 30, 0),
+        outcome=OutcomeStatus.correct,
+        actual_lowest_price_usd=164.5,
+        outcome_resolved_at=datetime(2026, 3, 28, 9, 0, 0),
+        savings_realized_usd=35.49,
+    ),
+    PredictionHistoryItem(
+        prediction_id="pred_20260320_02",
+        asin="B0BSHF7WHW",
+        product_title="USB-C Laptop Docking Station",
+        recommendation=RecommendationDirection.BUY,
+        confidence_pct=76.0,
+        price_at_prediction_usd=89.99,
+        predicted_best_price_usd=92.5,
+        horizon_days=14,
+        predicted_at=datetime(2026, 3, 10, 12, 15, 0),
+        outcome=OutcomeStatus.correct,
+        actual_lowest_price_usd=94.0,
+        outcome_resolved_at=datetime(2026, 3, 22, 16, 0, 0),
+        savings_realized_usd=0.0,
+    ),
+    PredictionHistoryItem(
+        prediction_id="pred_20260305_03",
+        asin="B09V3KXJPB",
+        product_title="Compact Mechanical Keyboard",
+        recommendation=RecommendationDirection.WAIT,
+        confidence_pct=71.0,
+        price_at_prediction_usd=99.99,
+        predicted_best_price_usd=84.0,
+        horizon_days=7,
+        predicted_at=datetime(2026, 2, 28, 9, 0, 0),
+        outcome=OutcomeStatus.incorrect,
+        actual_lowest_price_usd=97.5,
+        outcome_resolved_at=datetime(2026, 3, 7, 9, 0, 0),
+        savings_realized_usd=0.0,
+    ),
+    PredictionHistoryItem(
+        prediction_id="pred_20260401_04",
+        asin="B0CQMK4QTP",
+        product_title="Portable SSD 1TB",
+        recommendation=RecommendationDirection.WAIT,
+        confidence_pct=81.0,
+        price_at_prediction_usd=129.99,
+        predicted_best_price_usd=109.99,
+        horizon_days=14,
+        predicted_at=datetime(2026, 4, 1, 10, 0, 0),
+        outcome=OutcomeStatus.pending,
+        actual_lowest_price_usd=None,
+        outcome_resolved_at=None,
+        savings_realized_usd=None,
+    ),
+]
+
+_MOCK_WATCHLIST: List[WatchlistItem] = [
+    WatchlistItem(
+        asin="B0BSHF7WHW",
+        title="USB-C Laptop Docking Station",
+        brand="Anker",
+        category="Electronics",
+        current_price_usd=89.99,
+        currency="USD",
+        target_price_usd=74.99,
+        added_at=datetime(2026, 2, 10, 12, 0, 0),
+        last_price_change_pct=-3.2,
+        url="https://www.amazon.com/dp/B0BSHF7WHW",
+    ),
+    WatchlistItem(
+        asin="B0CQMK4QTP",
+        title="Portable SSD 1TB",
+        brand="Samsung",
+        category="Electronics",
+        current_price_usd=129.99,
+        currency="USD",
+        target_price_usd=109.99,
+        added_at=datetime(2026, 3, 22, 8, 30, 0),
+        last_price_change_pct=1.5,
+        url="https://www.amazon.com/dp/B0CQMK4QTP",
+    ),
+    WatchlistItem(
+        asin="B07ZPKBL9V",
+        title="Carry-On Spinner Luggage 21\"",
+        brand=None,
+        category="Travel Gear",
+        current_price_usd=149.0,
+        currency="USD",
+        target_price_usd=129.0,
+        added_at=datetime(2026, 1, 5, 19, 0, 0),
+        last_price_change_pct=-6.0,
+        url="https://www.amazon.com/dp/B07ZPKBL9V",
+    ),
+]
+
+
+# ── Handlers ──────────────────────────────────────────────────────────────────
+
+
+@router.get("/summary", response_model=DashboardSummaryResponse)
+def get_dashboard_summary() -> DashboardSummaryResponse:
+    return DashboardSummaryResponse(
+        user_id="user_demo_001",
+        total_predictions=47,
+        recommendations_followed=31,
+        estimated_savings_usd=284.5,
+        accuracy_when_followed_pct=82.3,
+        avg_confidence_when_correct_pct=79.1,
+        watchlist_count=len(_MOCK_WATCHLIST),
+        last_active_at=datetime(2026, 3, 28, 14, 22, 0),
+        period_label="Last 90 days",
+    )
+
+
+@router.get("/predictions/history", response_model=PredictionHistoryResponse)
+def get_prediction_history(
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+) -> PredictionHistoryResponse:
+    total = len(_MOCK_HISTORY)
+    slice_ = _MOCK_HISTORY[offset : offset + limit]
+    return PredictionHistoryResponse(
+        items=slice_,
+        total_count=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/watchlist", response_model=WatchlistResponse)
+def get_watchlist() -> WatchlistResponse:
+    return WatchlistResponse(items=_MOCK_WATCHLIST, total_count=len(_MOCK_WATCHLIST))
+
+
+@router.get("/market", response_model=MarketContextResponse)
+def get_market_context() -> MarketContextResponse:
+    return MarketContextResponse(
+        user_top_categories=["Electronics", "Computer Accessories", "Travel Gear"],
+        category_trends=[
+            CategoryMarketTrend(
+                category="Electronics › Audio",
+                median_price_change_7d_pct=-2.1,
+                median_price_change_30d_pct=-5.4,
+                deal_intensity_index=62.0,
+                sample_product_count=128,
+            ),
+            CategoryMarketTrend(
+                category="Electronics › Storage",
+                median_price_change_7d_pct=-1.3,
+                median_price_change_30d_pct=-3.8,
+                deal_intensity_index=55.0,
+                sample_product_count=96,
+            ),
+            CategoryMarketTrend(
+                category="Travel › Luggage",
+                median_price_change_7d_pct=0.4,
+                median_price_change_30d_pct=-2.0,
+                deal_intensity_index=48.0,
+                sample_product_count=54,
+            ),
+        ],
+        notable_movers=[
+            SegmentMover(
+                asin="B09V3KXJPB",
+                title="Compact Mechanical Keyboard",
+                category="Electronics › Keyboards",
+                price_change_7d_pct=-11.4,
+                current_price_usd=79.99,
+            ),
+            SegmentMover(
+                asin="B0BSHF7WHW",
+                title="USB-C Laptop Docking Station",
+                category="Electronics › Docks",
+                price_change_7d_pct=-3.2,
+                current_price_usd=89.99,
+            ),
+        ],
+        narrative=(
+            "Deals in your usual electronics categories are slightly stronger than "
+            "last month; headphones and docks show the steepest week-over-week drops."
+        ),
+        as_of=datetime(2026, 4, 1, 8, 0, 0),
+    )
+
+
+@router.get("/performance/timeseries", response_model=PerformanceTimeseriesResponse)
+def get_performance_timeseries() -> PerformanceTimeseriesResponse:
+    return PerformanceTimeseriesResponse(
+        granularity="week",
+        points=[
+            PerformancePeriodPoint(
+                period_start=datetime(2026, 1, 6, 0, 0, 0),
+                period_end=datetime(2026, 1, 12, 23, 59, 59),
+                predictions_made=6,
+                predictions_followed=4,
+                accuracy_pct=75.0,
+                savings_usd=42.0,
+            ),
+            PerformancePeriodPoint(
+                period_start=datetime(2026, 1, 13, 0, 0, 0),
+                period_end=datetime(2026, 1, 19, 23, 59, 59),
+                predictions_made=8,
+                predictions_followed=5,
+                accuracy_pct=80.0,
+                savings_usd=61.5,
+            ),
+            PerformancePeriodPoint(
+                period_start=datetime(2026, 1, 20, 0, 0, 0),
+                period_end=datetime(2026, 1, 26, 23, 59, 59),
+                predictions_made=5,
+                predictions_followed=3,
+                accuracy_pct=66.7,
+                savings_usd=28.0,
+            ),
+            PerformancePeriodPoint(
+                period_start=datetime(2026, 1, 27, 0, 0, 0),
+                period_end=datetime(2026, 2, 2, 23, 59, 59),
+                predictions_made=7,
+                predictions_followed=6,
+                accuracy_pct=83.3,
+                savings_usd=55.0,
+            ),
+            PerformancePeriodPoint(
+                period_start=datetime(2026, 2, 3, 0, 0, 0),
+                period_end=datetime(2026, 2, 9, 23, 59, 59),
+                predictions_made=9,
+                predictions_followed=7,
+                accuracy_pct=85.7,
+                savings_usd=98.0,
+            ),
+        ],
+    )
+
+
+@router.get("/performance/outcomes", response_model=OutcomeBreakdownResponse)
+def get_outcome_breakdown() -> OutcomeBreakdownResponse:
+    return OutcomeBreakdownResponse(
+        slices=[
+            OutcomeBreakdownSlice(outcome=OutcomeStatus.correct, count=26, share_pct=66.7),
+            OutcomeBreakdownSlice(outcome=OutcomeStatus.incorrect, count=8, share_pct=20.5),
+            OutcomeBreakdownSlice(outcome=OutcomeStatus.partial, count=3, share_pct=7.7),
+            OutcomeBreakdownSlice(outcome=OutcomeStatus.pending, count=2, share_pct=5.1),
+        ],
+        total_resolved=37,
+    )

--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Shared Pydantic-related types used by extension and dashboard APIs."""
+
+from schemas.common import RecommendationDirection
+
+__all__ = ["RecommendationDirection"]

--- a/backend/schemas/common.py
+++ b/backend/schemas/common.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class RecommendationDirection(str, Enum):
+    BUY = "BUY"
+    WAIT = "WAIT"

--- a/backend/tests/test_price_history_chart_fix.py
+++ b/backend/tests/test_price_history_chart_fix.py
@@ -1,0 +1,130 @@
+"""
+Regression: first-time product load should expose ~30 daily chart points with calendar
+labels (not weekly -4w buckets).
+
+Run: pytest tests/test_price_history_chart_fix.py -q
+"""
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    import main
+
+    return TestClient(main.app)
+
+
+def _synthetic_prices_desc(product_id: int, anchor: datetime):
+    """30 days of prices, newest first (matches DB ORDER BY timestamp DESC)."""
+    rows = []
+    for i in range(30):
+        ts = anchor.replace(hour=12, minute=0, second=0, microsecond=0) - timedelta(days=i)
+        rows.append(
+            {
+                "price_id": i,
+                "product_id": product_id,
+                "price": 100.0 + i * 0.5,
+                "timestamp": ts,
+                "availability": True,
+                "deal_flag": False,
+            }
+        )
+    return rows
+
+
+def _install_price_history_stubs(main, prices_desc, prediction, product_row):
+    """Works when MySQL import failed: endpoint still needs these names on main."""
+
+    calls = {"gp": 0}
+
+    def get_product(asin):
+        calls["gp"] += 1
+        if calls["gp"] == 1:
+            return None
+        return product_row
+
+    main.get_product = get_product
+    main._fetch_and_seed = lambda asin: None
+    main.db_get_price_history = MagicMock(return_value=prices_desc)
+    main.get_latest_prediction = MagicMock(return_value=prediction)
+    main._require_db = lambda: None
+
+
+def test_price_history_endpoint_daily_labels_and_count(client):
+    import main
+
+    anchor = datetime.utcnow().replace(hour=12, minute=0, second=0, microsecond=0)
+    product_row = {"product_id": 42, "asin": "B0VERIFYNEW1"}
+    prices_desc = _synthetic_prices_desc(42, anchor)
+    prediction = {"pred_7d": 95.0, "pred_14d": 94.0, "pred_30d": 92.0}
+
+    _install_price_history_stubs(main, prices_desc, prediction, product_row)
+
+    r = client.get("/price-history/B0VERIFYNEW1")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    labels = [p["label"] for p in body["points"]]
+    assert not any(l.startswith("-") and l.endswith("w") for l in labels), labels
+    assert any(c.isalpha() for c in labels[0]), labels
+    forecast_only = [
+        p for p in body["points"] if p.get("predicted") is not None and p.get("actual") is None
+    ]
+    assert len(forecast_only) == 3
+    assert len(body["points"]) >= 30
+    assert "30 days" in body["chart_title"] or "UTC" in body["chart_title"]
+
+
+def test_bucket_never_emits_weekly_minus_w_labels():
+    from main import _bucket_price_history
+
+    anchor = datetime.utcnow().replace(hour=12, minute=0, second=0, microsecond=0)
+    prices_desc = _synthetic_prices_desc(1, anchor)
+    pred = {"pred_7d": 90.0, "pred_14d": 89.0, "pred_30d": 88.0}
+    out = _bucket_price_history(prices_desc, pred, "B0X")
+    labels = [p.label for p in out.points]
+    assert all(not (l.startswith("-") and l.endswith("w")) for l in labels)
+    assert len(out.points) >= 30
+
+
+def test_keepa_passes_recorded_at_to_insert_price():
+    from pathlib import Path
+
+    text = Path(__file__).resolve().parents[1] / "jobs" / "keepa_fetch.py"
+    src = text.read_text(encoding="utf-8")
+    assert "recorded_at=ts" in src
+    assert "insert_price(product_id, record[\"price\"], availability=True, deal_flag=False)" not in src
+
+
+def test_insert_price_accepts_recorded_at():
+    from pathlib import Path
+
+    text = Path(__file__).resolve().parents[1] / "db" / "connection.py"
+    src = text.read_text(encoding="utf-8")
+    assert "recorded_at" in src
+    assert "recorded_at if recorded_at is not None else datetime.utcnow()" in src
+
+
+def test_extension_price_chart_keeps_full_month_range():
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[2] / "extension" / "src" / "components" / "PriceChart.tsx"
+    text = src.read_text(encoding="utf-8")
+    assert "firstForecastOnlyIndex" in text
+    assert 'range === "1M"' in text
+    # Old bug: 1M sliced to 6 points (weekly assumption)
+    assert "Math.min(points.length, 6)" not in text
+
+
+def test_main_uses_limit_1000_for_history():
+    from pathlib import Path
+    import re
+
+    text = Path(__file__).resolve().parents[1] / "main.py"
+    src = text.read_text(encoding="utf-8")
+    assert src.count("db_get_price_history(product[\"product_id\"], limit=1000)") >= 2
+    assert re.search(r"db_get_price_history\([^)]*limit=100\)", src) is None

--- a/extension/src/components/PriceChart.tsx
+++ b/extension/src/components/PriceChart.tsx
@@ -33,13 +33,33 @@ const RANGE_OPTIONS: RangeOption[] = ["2W", "1M", "ALL"];
 const formatMoney = (value: number): string => `$${Math.round(value)}`;
 const formatDelta = (value: number): string => `${value > 0 ? "+" : ""}${value.toFixed(1)}%`;
 
+const firstForecastOnlyIndex = (points: PricePoint[]): number => {
+  const idx = points.findIndex(
+    (p) => typeof p.predicted === "number" && typeof p.actual !== "number"
+  );
+  return idx === -1 ? points.length : idx;
+};
+
 const clampRange = (points: PricePoint[], range: RangeOption): PricePoint[] => {
-  if (range === "ALL") {
+  if (range === "ALL" || points.length === 0) {
     return points;
   }
 
-  const size = range === "2W" ? Math.min(points.length, 4) : Math.min(points.length, 6);
-  return points.slice(points.length - size);
+  const split = firstForecastOnlyIndex(points);
+  const history = points.slice(0, split);
+  const forecastTail = points.slice(split);
+
+  if (range === "1M") {
+    return points;
+  }
+
+  if (range === "2W") {
+    const window = 15;
+    const histShown = history.slice(Math.max(0, history.length - window));
+    return [...histShown, ...forecastTail];
+  }
+
+  return points;
 };
 
 const toChartData = (points: PricePoint[], mode: AxisMode): ChartDatum[] => {


### PR DESCRIPTION
The root cause was that insert_price was storing datetime.now() as the timestamp for every Keepa data point, collapsing all historical rows onto a single day. As a result, the weekly bucketing logic in _bucket_price_history had no spread to work with and only one bucket ever had data. keepa_fetch.py now passes the real Keepa timestamp into insert_price, the bucketing logic has been replaced with 30 UTC calendar days using forward-fill, history fetches use limit=1000, and PriceChart.tsx no longer slices the series to 6 points. Six regression tests in tests/test_price_history_chart_fix.py cover all layers. Full live verification against a real ASIN requires MySQL and a Keepa API key configured locally.

Closes #25 